### PR TITLE
New endpoints, dashboard fix, recent reviews, and new returned status

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,9 +8,11 @@
       "name": "keylab",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.4.8",
         "keylab": "file:",
         "lucide-react": "^0.453.0",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0"
       },
@@ -995,6 +997,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1928,6 +1936,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -3478,6 +3498,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,9 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.4.8",
     "keylab": "file:",
     "lucide-react": "^0.453.0",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0"
   },

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
 				),
 			},
 			{
-				// path: "/Dashboard", element: <AdminDashboard/>,
+				path: "/admin/dashboard", element: <AdminDashboard/>,
 			},
 			{ path: "/sign-in", element: <SignIn /> },
 			{ path: "/register", element: <Register /> },

--- a/server/database/db.go
+++ b/server/database/db.go
@@ -115,9 +115,9 @@ func runSeeder(db *gorm.DB) error {
 		log.Println("Database seeded successfully")
 		return nil
 	} else {
-		if err := seeders.CleanTables(db); err != nil {
-			return fmt.Errorf("could not clean tables: %w", err)
-		}
+		// if err := seeders.CleanTables(db); err != nil {
+		// 	return fmt.Errorf("could not clean tables: %w", err)
+		// }
 
 		log.Println("Database test seeding is disabled")
 		return nil

--- a/server/database/migrations/000022_alter_orders_table_status.down.sql
+++ b/server/database/migrations/000022_alter_orders_table_status.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+MODIFY COLUMN status ENUM('pending','shipped','delivered','cancelled') NOT NULL;

--- a/server/database/migrations/000022_alter_orders_table_status.up.sql
+++ b/server/database/migrations/000022_alter_orders_table_status.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+MODIFY COLUMN status ENUM('pending','shipped','delivered','cancelled','returned') NOT NULL;

--- a/server/database/models/Order.go
+++ b/server/database/models/Order.go
@@ -13,23 +13,31 @@ const (
 	Shipped   OrderStatus = "shipped"
 	Delivered OrderStatus = "delivered"
 	Cancelled OrderStatus = "cancelled"
+	Returned  OrderStatus = "returned"
 )
 
 type Order struct {
-	ID                int64       `gorm:"primaryKey;autoIncrement" json:"id"`
-	UserID            int64       `gorm:"not null" json:"user_id"`
-	OrderDate         time.Time   `ggorm:"default:CURRENT_TIMESTAMP" json:"order_date"`
-	Status            OrderStatus `gorm:"type:ENUM('pending','shipped','delivered','cancelled');not null" json:"status"`
-	Total             float64     `gorm:"type:DECIMAL(10,2);not null" json:"total"`
-	ShippingAddressID int64       `gorm:"column:shipping_address;not null" json:"shipping_address_id"`
-	BillingAddressID  int64       `gorm:"column:billing_address;not null" json:"billing_address_id"`
-	ShippingAddress   *Address    `gorm:"foreignKey:ShippingAddressID" json:"shipping_address"`
-	BillingAddress    *Address    `gorm:"foreignKey:BillingAddressID" json:"billing_address"`
-	CreatedAt         time.Time   `gorm:"default:CURRENT_TIMESTAMP" json:"created_at"`
-	UpdatedAt         time.Time   `gorm:"default:CURRENT_TIMESTAMP;autoUpdateTime" json:"updated_at"`
+	ID                int64         `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID            int64         `gorm:"not null" json:"user_id"`
+	User              User          `gorm:"foreignKey:UserID" json:"user"`
+	OrderDate         time.Time     `gorm:"default:CURRENT_TIMESTAMP" json:"order_date"`
+	Status            OrderStatus   `gorm:"type:ENUM('pending','shipped','delivered','cancelled', 'returned');not null" json:"status"`
+	Total             float64       `gorm:"type:DECIMAL(10,2);not null" json:"total"`
+	ShippingAddressID int64         `gorm:"column:shipping_address;not null" json:"shipping_address_id"`
+	BillingAddressID  int64         `gorm:"column:billing_address;not null" json:"billing_address_id"`
+	ShippingAddress   *Address      `gorm:"foreignKey:ShippingAddressID" json:"shipping_address"`
+	BillingAddress    *Address      `gorm:"foreignKey:BillingAddressID" json:"billing_address"`
+	OrderedItems      []OrderedItem `gorm:"foreignKey:OrderID" json:"ordered_items"`
+	CreatedAt         time.Time     `gorm:"default:CURRENT_TIMESTAMP" json:"created_at"`
+	UpdatedAt         time.Time     `gorm:"default:CURRENT_TIMESTAMP;autoUpdateTime" json:"updated_at"`
 }
 
-func (o *Order) Validate() error {
+func (o *Order) Validate(fields ...string) error {
 	validate := validator.New()
+
+	if len(fields) > 0 {
+		return validate.StructPartial(o, fields...)
+	}
+
 	return validate.Struct(o)
 }

--- a/server/database/models/OrderedItems.go
+++ b/server/database/models/OrderedItems.go
@@ -9,14 +9,21 @@ import (
 type OrderedItem struct {
 	ID        int64     `gorm:"primaryKey;autoIncrement" json:"id"`
 	OrderID   int64     `gorm:"not null" json:"order_id"`
+	Order     Order     `gorm:"foreignKey:OrderID" json:"order"`
 	ProductID int64     `gorm:"not null" json:"product_id"`
+	Product   Product   `gorm:"foreignKey:ProductID" json:"product"`
 	Quantity  int       `gorm:"not null" json:"quantity"`
 	Price     float64   `gorm:"type:DECIMAL(10,2);not null" json:"price"`
 	CreatedAt time.Time `gorm:"default:CURRENT_TIMESTAMP" json:"created_at"`
 	UpdatedAt time.Time `gorm:"default:CURRENT_TIMESTAMP;autoUpdateTime" json:"updated_at"`
 }
 
-func (oi *OrderedItem) Validate() error {
+func (oi *OrderedItem) Validate(fields ...string) error {
 	validate := validator.New()
+
+	if len(fields) > 0 {
+		return validate.StructPartial(oi, fields...)
+	}
+
 	return validate.Struct(oi)
 }

--- a/server/handlers/Cart.go
+++ b/server/handlers/Cart.go
@@ -322,6 +322,7 @@ func (h *Handlers) UpdateOrderStatus(c echo.Context) error {
 		"shipped":   true,
 		"delivered": true,
 		"cancelled": true,
+		"returned":  true,
 	}
 
 	status := strings.ToLower(requestBody.Status)
@@ -344,4 +345,159 @@ func (h *Handlers) UpdateOrderStatus(c echo.Context) error {
 	}
 
 	return jsonResponse(c, http.StatusOK, "Order status updated successfully", order)
+}
+
+// GetAllOrders Handler [GET /admin/orders]
+// 1. Fetches all orders with pagination
+// 2. Returns status 200 with orders data and pagination metadata if successful
+// 3. Returns status 500 if an error occurs
+
+func (h *Handlers) GetAllOrders(c echo.Context) error {
+	page, perPage, offset := getPaginationParams(c)
+	order := getSortOrder(c)
+
+	status := c.QueryParam("status")
+
+	var orders []models.Order
+	query := h.DB.Preload("User").Preload("ShippingAddress").Preload("BillingAddress").Order(order)
+
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
+
+	if err := query.Limit(perPage).Offset(offset).Find(&orders).Error; err != nil {
+		log.Printf("Error fetching orders: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Error fetching orders")
+	}
+
+	var total int64
+	countQuery := h.DB.Model(&models.Order{})
+	if status != "" {
+		countQuery = countQuery.Where("status = ?", status)
+	}
+
+	if err := countQuery.Count(&total).Error; err != nil {
+		log.Printf("Error counting orders: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Error counting orders")
+	}
+
+	var processedOrders []map[string]interface{}
+	for _, order := range orders {
+		var orderedItems []models.OrderedItem
+		if err := h.DB.Preload("Product").Where("order_id = ?", order.ID).Find(&orderedItems).Error; err != nil {
+			log.Printf("Error fetching ordered items for order %d: %v", order.ID, err)
+			continue
+		}
+
+		processedOrders = append(processedOrders, map[string]interface{}{
+			"order":         order,
+			"ordered_items": orderedItems,
+		})
+	}
+
+	return jsonResponse(c, http.StatusOK, "Orders fetched successfully", map[string]interface{}{
+		"orders":   processedOrders,
+		"metadata": generatePaginationResponse(page, perPage, int(total)),
+	})
+}
+
+// GetOrderDetails Handler [GET /admin/orders/:id]
+// 1. Fetches a specific order by ID with all related data
+// 2. Returns status 200 with order data if successful
+// 3. Returns status 404 if order not found
+// 4. Returns status 500 if an error occurs
+
+func (h *Handlers) GetOrderDetails(c echo.Context) error {
+	orderID, err := convertToInt64(c.Param("id"))
+	if err != nil {
+		return jsonResponse(c, http.StatusBadRequest, "Invalid order ID")
+	}
+
+	var order models.Order
+	if err := h.DB.Preload("User").Preload("ShippingAddress").Preload("BillingAddress").Where("id = ?", orderID).First(&order).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return jsonResponse(c, http.StatusNotFound, "Order not found")
+		}
+		log.Printf("Error fetching order details: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Error fetching order details")
+	}
+
+	var orderedItems []models.OrderedItem
+	if err := h.DB.Preload("Product").Where("order_id = ?", orderID).Find(&orderedItems).Error; err != nil {
+		log.Printf("Error fetching ordered items: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Failed to fetch ordered items")
+	}
+
+	response := map[string]interface{}{
+		"order":         order,
+		"ordered_items": orderedItems,
+	}
+
+	return jsonResponse(c, http.StatusOK, "Order found", response)
+}
+
+// GetUserOrders Handler [GET /admin/users/:id/orders]
+// 1. Fetches all orders for a specific user with pagination
+// 2. Returns status 200 with orders data and pagination metadata if successful
+// 3. Returns status 404 if user not found
+// 4. Returns status 500 if an error occurs
+
+func (h *Handlers) GetUserOrders(c echo.Context) error {
+	userID, err := convertToInt64(c.Param("id"))
+	if err != nil {
+		return jsonResponse(c, http.StatusBadRequest, "Invalid user ID")
+	}
+
+	user, err := repositories.FindUserByID(userID, h.DB)
+	if err != nil {
+		return jsonResponse(c, http.StatusNotFound, "User not found")
+	}
+
+	page, perPage, offset := getPaginationParams(c)
+	order := getSortOrder(c)
+
+	status := c.QueryParam("status")
+
+	var orders []models.Order
+	query := h.DB.Preload("User").Preload("ShippingAddress").Preload("BillingAddress").Where("user_id = ?", user.ID).Order(order)
+
+	if status != "" {
+		query = query.Where("status = ?", status)
+	}
+
+	if err := query.Limit(perPage).Offset(offset).Find(&orders).Error; err != nil {
+		log.Printf("Error fetching user orders: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Error fetching user orders")
+	}
+
+	var total int64
+	countQuery := h.DB.Model(&models.Order{}).Where("user_id = ?", user.ID)
+	if status != "" {
+		countQuery = countQuery.Where("status = ?", status)
+	}
+
+	if err := countQuery.Count(&total).Error; err != nil {
+		log.Printf("Error counting user orders: %v", err)
+		return jsonResponse(c, http.StatusInternalServerError, "Error counting user orders")
+	}
+
+	var processedOrders []map[string]interface{}
+	for _, order := range orders {
+		var orderedItems []models.OrderedItem
+		if err := h.DB.Preload("Product").Where("order_id = ?", order.ID).Find(&orderedItems).Error; err != nil {
+			log.Printf("Error fetching ordered items for order %d: %v", order.ID, err)
+			continue
+		}
+
+		processedOrders = append(processedOrders, map[string]interface{}{
+			"order":         order,
+			"ordered_items": orderedItems,
+		})
+	}
+
+	return jsonResponse(c, http.StatusOK, "User orders fetched successfully", map[string]interface{}{
+		"user":     user,
+		"orders":   processedOrders,
+		"metadata": generatePaginationResponse(page, perPage, int(total)),
+	})
 }

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -61,6 +61,7 @@ func RegisterRoutes(e *echo.Echo, sessionStore *sessions.CookieStore, db *gorm.D
 	productReviewGroup.PUT("/:id", h.UpdateReview, middleware.AuthMiddleware(sessionStore, db))
 	productReviewGroup.DELETE("/:id", h.DeleteReview, middleware.AuthMiddleware(sessionStore, db))
 	productReviewGroup.GET("/user", h.GetUserReview, middleware.AuthMiddleware(sessionStore, db))
+	e.GET("/reviews/recent", h.FetchRecentViews)
 
 	// // Cart related routes
 	cartGroup := e.Group("/cart", middleware.AuthMiddleware(sessionStore, db))
@@ -72,8 +73,16 @@ func RegisterRoutes(e *echo.Echo, sessionStore *sessions.CookieStore, db *gorm.D
 
 	// // Orders related routes
 	e.GET("/user/orders/:id", h.GetUserOrderDetails, middleware.AuthMiddleware(sessionStore, db))
-	// // NEEDS ADMIN MIDDLEWARE
-	e.PUT("/orders/:id/status", h.UpdateOrderStatus)
 
 	e.POST("/contact", h.ContactUs)
+
+	// NEEDS ADMIN MIDDLEWARE
+	adminUserGroup := e.Group("/admin", middleware.AuthMiddleware(sessionStore, db))
+	adminUserGroup.GET("/users", h.GetAllUsers)
+
+	adminOrdersGroup := e.Group("/admin/orders", middleware.AuthMiddleware(sessionStore, db))
+	adminOrdersGroup.GET("", h.GetAllOrders)
+	adminOrdersGroup.GET("/:id", h.GetOrderDetails)
+	adminOrdersGroup.GET("/user/:id", h.GetUserOrders)
+	adminOrdersGroup.PUT("/:id/status", h.UpdateOrderStatus)
 }


### PR DESCRIPTION
Another decently sized branch.

#### Fixes & Altering
- Fixes the missing `Chart.JS` npm packages for the /client/dashboard page.  
- Changed the frontend route for the Dashboard page from `/Dashboard` to `/admin/dashboard`
- Adds proper foreign key relations to the `Order` & `OrderItems` model so we can preload data
- Adds migrations to alter the `Orders` table to add an additional `Returned` status. Following this, I modified the backend to allow for the `Returned` ENUM

#### Endpoints
- Implements recent reviews endpoints. By default it fetches 5 of the most recent, but can take in a Query Parameter specifying a limit. Such as `/reviews/recent?limit=10`
- Implements endpoint to fetch all users at `/admin/orders`. This includes filtering and pagination - same as it is in products. `?page=1&per_page=20` and `?sort=created_at&order=desc` 
- Implements `GET /admin/orders` to fetch all orders by all users. This also contains pagination and sorting. `?page=1&per_page=20` and `?sort=created_at&order=desc` 
- Implements `GET /admin/orders/:id` to fetch a specific orders details - includes all ordered items related to it automatically.
- Implements `GET /admin/orders/user/:id` to fetch a specific users orders - includes pagination, sorting and query param for status filtering
- Renamed `PUT /orders/:id/status` to `PUT /admin/orders/:id/status` but the functionality is the same.


**The admin routes do not include their middleware currently, this is simply to make it easier for the frontend team to speed through what needs to be done.**